### PR TITLE
fix typos in comments and tests

### DIFF
--- a/fcors.go
+++ b/fcors.go
@@ -359,7 +359,7 @@ func WithAnyRequestHeaders() Option {
 	return internal.WithAnyRequestHeaders()
 }
 
-// MaxAgeInSeconds configures a CORS middleware to intruct browsers to
+// MaxAgeInSeconds configures a CORS middleware to instruct browsers to
 // cache preflight responses for a maximum duration of delta seconds.
 //
 // Specifying a max-age value of 0 instructs browsers to eschew caching of

--- a/internal/methods_test.go
+++ b/internal/methods_test.go
@@ -7,7 +7,7 @@ import (
 func TestThatAllForbiddenMethodsAreByteLowercase(t *testing.T) {
 	for method := range byteLowercasedForbiddenMethods {
 		if byteLowercase(method) != method {
-			t.Errorf("forbidden method %q is not byte-lowecase", method)
+			t.Errorf("forbidden method %q is not byte-lowercase", method)
 		}
 	}
 }

--- a/internal/origin/spec.go
+++ b/internal/origin/spec.go
@@ -82,7 +82,7 @@ func (s *Spec) IsDeemedInsecure() bool {
 func (s *Spec) HostIsEffectiveTLD() (string, bool) {
 	host := s.HostPattern.hostOnly()
 	// For cases like of a Web origin that ends with a full stop,
-	// we need to to trim the latter for this check.
+	// we need to trim the latter for this check.
 	host = strings.TrimSuffix(host, string(fullStop))
 	// We ignore the second (boolean) result because
 	// it's false for some listed eTLDs (e.g. github.io)


### PR DESCRIPTION
This PR fixes typos and removes the duplicated word `to`.


